### PR TITLE
Move jasmine to devDependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,9 @@
         "url": "git://github.com/jylauril/jquery-runner.git"
     },
     "dependencies": {
-        "jquery": "~1.9.1",
+        "jquery": "~1.9.1"
+    },
+    "devDependencies": {
         "jasmine-sinon": "~0.1.0",
         "jasmine-matchers": "git://github.com/JamieMason/Jasmine-Matchers.git"
     }


### PR DESCRIPTION
This way, bower doesn't install them when installing jquery.runner as a component.
